### PR TITLE
Hide useless admin options when adding new page section using Layout Paragraphs

### DIFF
--- a/localgov_page.module
+++ b/localgov_page.module
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @file
+ * LocalGov Page module file.
+ */
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_form_alter().
+ */
+function localgov_page_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+
+  // Hide useless admin options when adding new section using Layout Paragraphs.
+  if (isset($form['localgov_page_content']['widget']['entity_form']['layout_plugin_form'])) {
+    $form['localgov_page_content']['widget']['entity_form']['layout_plugin_form']['#access'] = FALSE;
+  }
+}


### PR DESCRIPTION
Fixes localgovdrupal/localgov_microsites#124