### PR TITLE
Removes unneeded _form_alter

### DIFF
--- a/localgov_page.module
+++ b/localgov_page.module
@@ -4,16 +4,3 @@
  * @file
  * LocalGov Page module file.
  */
-
-use Drupal\Core\Form\FormStateInterface;
-
-/**
- * Implements hook_form_alter().
- */
-function localgov_page_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-
-  // Hide useless admin options when adding new section using Layout Paragraphs.
-  if (isset($form['localgov_page_content']['widget']['entity_form']['layout_plugin_form'])) {
-    $form['localgov_page_content']['widget']['entity_form']['layout_plugin_form']['#access'] = FALSE;
-  }
-}


### PR DESCRIPTION
This _form_alter doesn't work anymore, and i've moved it to localgov_paragraphs https://github.com/localgovdrupal/localgov_paragraphs/pull/67