### PR TITLE
Remove dependency on Layout Paragraphs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
     "license": "GPL-2.0-or-later",
     "minimum-stability": "dev",
     "require": {
-        "drupal/layout_paragraphs": "^1.0",
         "localgovdrupal/localgov_core": "^2.0",
         "localgovdrupal/localgov_paragraphs": "^2.0"
     },

--- a/config/install/core.entity_view_display.node.localgov_page.default.yml
+++ b/config/install/core.entity_view_display.node.localgov_page.default.yml
@@ -78,7 +78,7 @@ content:
     label: hidden
     settings:
       view_mode: default
-      link: false
+      link: ''
     third_party_settings: {  }
     weight: 2
     region: content


### PR DESCRIPTION
Dependency on Layout Paragraphs with be added to LocalGov Paragraphs. This will allow use to upgrade to Layout Paragraphs 2.x without further releases.

 Fixes #36

See also:
- https://github.com/localgovdrupal/localgov_subsites/pull/85
- https://github.com/localgovdrupal/localgov_subsites/pull/109
- https://github.com/localgovdrupal/localgov_paragraphs/pull/83
- https://github.com/localgovdrupal/localgov_microsites/issues/84